### PR TITLE
Resolve bugs

### DIFF
--- a/R/addGeoArrowPolygonLayer.R
+++ b/R/addGeoArrowPolygonLayer.R
@@ -90,7 +90,11 @@ addGeoArrowPolygonLayer_default = function(
     )
   }
 
-  path_layer = writeGeoarrow(data, layerId, geom_column_name)
+  path_layer = writeGeoarrow(
+    data
+    , layerId = layerId
+    , geom_column_name = geom_column_name
+  )
 
   map$dependencies = c(
     map$dependencies

--- a/R/internals.R
+++ b/R/internals.R
@@ -18,9 +18,9 @@ writeGeoarrow = function(
   )
 
   data_stream = nanoarrow::as_nanoarrow_array_stream(
-    dat
+    data
     , geometry_schema = geoarrow::infer_geoarrow_schema(
-      dat
+      data
       , coord_type = ifelse(interleaved, "INTERLEAVED", "SEPARATE")
     )
   )

--- a/dev_history.R
+++ b/dev_history.R
@@ -47,7 +47,10 @@ m = maplibre(
   ) |>
   add_layers_control(
     collapsible = TRUE
-    , layers = c("aoi")
+    , layers = c(
+      "aoi"
+      , "parcels"
+    )
   ) |>
   fit_bounds(
     unname(st_bbox(aoi))
@@ -65,6 +68,18 @@ m |>
     , data_accessors = geoarrowDeckgl:::dataAccessors(
       getFillColor = c(153, 142, 195, 128)
       , getLineColor = c(153, 142, 195, 128)
+    )
+    , popup = TRUE
+  ) |>
+  geoarrowDeckgl:::addGeoArrowPolygonLayer(
+    data = parcels
+    , layerId = "parcels"
+    , geom_column_name = attr(parcels, "sf_column")
+    , render_options = geoarrowDeckgl:::renderOptions(
+      extruded = FALSE
+    )
+    , data_accessors = geoarrowDeckgl:::dataAccessors(
+      getFillColor = c(241, 163, 64, 192)
       , getLineWidth = 1
     )
     , popup = TRUE

--- a/dev_history.R
+++ b/dev_history.R
@@ -1,0 +1,35 @@
+# 2025-11-15 ====
+
+## TEST WITH 2+ POLYGONS LAYERS ====
+
+library(osmdata)
+library(sf)
+
+## get area of interest from osm
+aoi = opq_osm_id (
+  type = "relation"
+  , id = 1152702
+) |>
+  opq_string () |>
+  osmdata_sf () |> 
+  getElement("osm_multipolygons") |> 
+  st_transform(
+    crs = 25832L
+  )
+
+## download parcels
+cli = ows4R::WFSClient$new(
+  "https://geo5.service24.rlp.de/wfs/alkis_rp.fcgi"
+  , serviceVersion = "2.0.0"
+)
+
+parcels = cli$getFeatures(
+  "ave:Flurstueck"
+  , bbox = paste(
+    st_bbox(aoi)
+    , collapse = ","
+  )
+) |> 
+  st_transform(
+    crs = 4326L
+  )


### PR DESCRIPTION
Resolve bugs encountered during testing:
- [x] leftover `dat` reference in `writeGeoarrow()` function definition &rarr; afff6de1beeb18898a25ea02712e282010fd6b98
- [x] incorrect allocation of arguments while calling `writeGeoarrow()` &rarr; 7bc7e8a600bc66eaa9b7cb5b621e321beda402bf